### PR TITLE
Invoke prisma generate upon running prisma:patchCasing

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -4,7 +4,7 @@
   "main": "index.ts",
   "scripts": {
     "prisma:generate": "prisma generate",
-    "prisma:patchCasing": "node ./prisma/scripts/casingFix.js && prisma format",
+    "prisma:patchCasing": "node ./prisma/scripts/casingFix.js && prisma format && prisma generate",
     "prisma:compile": "tsc --project tsconfig.compile.json",
     "prisma:seed": "prisma db seed"
   },


### PR DESCRIPTION
# Invoke prisma generate upon running prisma:patchCasing

The Prisma client needs to be re-generated everytime the Prisma Schema is updated so as to reflect the latest changes.

Currently, `prisma:patchCasing` does not invoke `prisma generate` automatically. This PR fixes that. This way, running `prisma:patchCasing` will format the prisma schema and generate a updated prisma client with the changes applied.

## Types of Changes

<!-- What types of changes does your code introduce? Please tick all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Issue fix (non-breaking change that addresses existing opened issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring change (refactoring change must not apply any form of functional change)

## Fixes
N/A

## Notion Task Coverage
N/A
