### PR TITLE
Fixes the build script for the errors package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev:chat": "nx run @inc/chat:dev",
     "test": "nx run-many -t test",
     "build": "nx run-many -t build",
-    "build:packages": "nx run-many -t build -p @inc/ui @inc/events @inc/s3-simplified --parallel=3",
+    "build:packages": "nx run-many -t build -p @inc/ui @inc/events @inc/s3-simplified @inc/errors --parallel=4",
     "build:ui": "nx run @inc/ui:build",
     "build:events": "nx run @inc/events:build",
     "build:s3": "nx run @inc/s3-simplified:build",

--- a/packages/errors/tsconfig.json
+++ b/packages/errors/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "lib": [
       "dom",


### PR DESCRIPTION
# Fixes the build script for the errors package

The errors package was previously compiled for ES5, causing `typeof` checks to break for classes. This PR fixes that.


## Types of Changes

<!-- What types of changes does your code introduce? Please tick all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Issue fix (non-breaking change that addresses existing opened issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring change (refactoring change must not apply any form of functional change)

## Fixes
N/A

## Notion Task Coverage
N/A
