### PR TITLE
Chat Server - Add support for event acknowledgement callback

### DIFF
--- a/apps/chat/src/socket.ts
+++ b/apps/chat/src/socket.ts
@@ -13,14 +13,14 @@ export default (io: Server) => {
     logger.info(`${socket.id} is connected.`);
     let eventsAttached: string[] = [];
     for (const event of Object.values(events)) {
-      const { callback, eventName, type } = event(io);
+      const { callback, eventName, type } = event(io, socket);
       socket[type](eventName, callback);
       eventsAttached.push(eventName);
     }
 
     socket.once(EVENTS.CONNECTION.DISCONNECT, () => {
       logger.info(`Disconnected: ${socket.id}`);
-    })
+    });
 
     logger.info(`Attached ${eventsAttached.length} events to ${socket.id}`);
   });

--- a/packages/events/index.ts
+++ b/packages/events/index.ts
@@ -9,7 +9,7 @@ export const EVENTS = {
 
   // Client Events
   CLIENT: {
-    DELETE_MESSAGE: 'deleteMessage',
+    DELETE_MESSAGE: 'clientDeleteMessage',
     CREATE_ROOM: 'createRoom',
     SEND_MESSAGE: 'sendMessage',
     PING: 'clientPing',
@@ -21,6 +21,7 @@ export const EVENTS = {
   // Server Events
   SERVER: {
     ROOMS: 'rooms',
+    DELETE_MESSAGE: 'serverDeleteMessage',
     JOINED_ROOM: 'joinedRoom',
     ROOM_MESSAGE: 'roomMessage',
     PING: 'serverPing',
@@ -32,8 +33,8 @@ export const EVENTS = {
 
 type DeepValueOf<T extends Record<string, unknown>, Key = keyof T> = Key extends string
   ? T[Key] extends Record<string, unknown>
-  ? DeepValueOf<T[Key]>
-  : T[keyof T]
+    ? DeepValueOf<T[Key]>
+    : T[keyof T]
   : never;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type DeclaredEventsObj = Extract<DeepValueOf<typeof EVENTS>, string>;

--- a/packages/types/events/index.ts
+++ b/packages/types/events/index.ts
@@ -14,6 +14,11 @@ type RoomMessage = {
   time: Date;
 };
 
+type DeleteMessage = {
+  room: string;
+  message: number;
+};
+
 type StartStopType = {
   sender: string;
   roomId: string;
@@ -23,7 +28,6 @@ type Read = {
   room: string;
   message: string;
 };
-
 
 // EventParams keys must match all the available events above in the const object.
 type EventParams = {
@@ -35,7 +39,7 @@ type EventParams = {
   createRoom: { roomName: string };
   sendMessage: RoomMessage;
   clientPing: string;
-  deleteMessage: { room: string; message: number };
+  clientDeleteMessage: DeleteMessage;
   clientStartType: StartStopType;
   clientStopType: StartStopType;
   clientRead: Read;
@@ -44,6 +48,7 @@ type EventParams = {
   rooms: Record<string, Room>;
   joinedRoom: Room;
   roomMessage: RoomMessage;
+  serverDeleteMessage: DeleteMessage;
   serverPing: string;
   serverStartType: StartStopType;
   serverStopType: StartStopType;
@@ -52,10 +57,13 @@ type EventParams = {
 
 type Event = keyof EventParams;
 
-type EventFile = (io: Server) => {
+type EventFile = (
+  io: Server,
+  socket?: Socket
+) => {
   [K in keyof EventParams]: {
     eventName: K;
-    callback: (param: EventParams[K]) => void;
+    callback: (param: EventParams[K], callback?: (...args: any[]) => void) => void;
     type: 'on' | 'once';
   };
 }[keyof EventParams];


### PR DESCRIPTION
# Chat Server - Add support for event acknowledgement callback

1. Chat server event files can now specify a second parameter to the `callback` function to accept an acknowledgement callback:

![image](https://github.com/kKar1503/project-inc-siwma-2/assets/33229805/04098d00-bfed-4b1d-8003-99d24e696ff5)
![image](https://github.com/kKar1503/project-inc-siwma-2/assets/33229805/ba0be0d4-a573-4d78-8910-1653eeeb812e)


2. Chat server event files can now accept the `socket` connection object for use in the event:

![image](https://github.com/kKar1503/project-inc-siwma-2/assets/33229805/2a7d54fb-0514-4981-961f-d5f77cc2d5f8)

3. Fix build errors that were introduced into dev by PR #108

## Types of Changes

<!-- What types of changes does your code introduce? Please tick all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Issue fix (non-breaking change that addresses existing opened issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring change (refactoring change must not apply any form of functional change)

## Fixes
N/A

## Notion Task Coverage
- Update Chat Server - Allow event callbacks