### PR TITLE
Fix bug with `GET /chat/:id/messages` response body

### DIFF
--- a/apps/marketplace/src/pages/api/v1/chat/[id]/messages.ts
+++ b/apps/marketplace/src/pages/api/v1/chat/[id]/messages.ts
@@ -1,7 +1,8 @@
 import { apiHandler, formatAPIResponse } from '@/utils/api';
-import PrismaClient from '@inc/db';
+import PrismaClient, { Messages } from '@inc/db';
 import { NotFoundError, InvalidRangeError, ForbiddenError } from '@inc/errors';
 import { chatSchema } from '@/utils/api/server/zod';
+import { ChatMessage } from '@/utils/api/client/zod/chat';
 import { checkChatExists } from '.';
 
 async function getMessages(chatId: string, lastIdPointer: number, limit: number) {
@@ -20,6 +21,26 @@ async function getMessages(chatId: string, lastIdPointer: number, limit: number)
   });
 
   return messages;
+}
+
+function formatMessageResponse(message: Messages) {
+  // Construct base response
+  const response: ChatMessage = {
+    id: message.id.toString(),
+    contentType: message.contentType,
+    read: message.read,
+    author: message.author,
+    createdAt: message.createdAt.toISOString(),
+  };
+
+  // Format the message based on the content type
+  if (message.contentType !== 'offer') {
+    response.content = message.content;
+  } else {
+    response.offer = message.offer;
+  }
+
+  return response;
 }
 
 export default apiHandler().get(async (req, res) => {
@@ -54,14 +75,7 @@ export default apiHandler().get(async (req, res) => {
   const messages = await getMessages(id, lastIdPointer || 0, limit);
 
   // Format messages
-  const formattedMessages = messages.map((message) => ({
-    id: message.id.toString(),
-    contentType: message.contentType,
-    read: message.read,
-    offer: message.offer,
-    author: message.author,
-    createdAt: message.createdAt.toISOString(),
-  }));
+  const formattedMessages = messages.map(formatMessageResponse);
 
   // Return the result
   res.status(200).json(formatAPIResponse(formattedMessages));

--- a/apps/marketplace/src/utils/api/client/zod/chat.ts
+++ b/apps/marketplace/src/utils/api/client/zod/chat.ts
@@ -33,7 +33,7 @@ const getUserChat = z.object({
 const getUserChats = getUserChat.array();
 
 export type ChatRoom = z.infer<typeof getChatRoom>;
-export type ChatMessage = z.infer<typeof getChatMessages>;
+export type ChatMessage = z.infer<typeof getChatMessage>;
 export type Chat = z.infer<typeof getUserChat>;
 
 export default {


### PR DESCRIPTION
# Fix bug with `GET /chat/:id/messages` response body

This PR fixes the following bugs with `GET /chat/:id/messages`:
- The response body wouldn't contain the `content` key, which is a pretty important key lol.
- The response body would contain the `offer` key all the time, even when the message did not contain an offer.

There was a 

## Types of Changes

<!-- What types of changes does your code introduce? Please tick all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Issue fix (non-breaking change that addresses existing opened issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring change (refactoring change must not apply any form of functional change)

## Fixes
N/A

## Notion Task Coverage
N/A