### PR TITLE
fix: :bug: GET companies/:id toISOString on undefined

### DIFF
--- a/apps/marketplace/src/pages/api/v1/companies/[id]/index.ts
+++ b/apps/marketplace/src/pages/api/v1/companies/[id]/index.ts
@@ -32,7 +32,7 @@ function formatResponse(r: Companies): CompanyResponseBody {
     image: r.logo,
     visible: r.visibility,
     comments: r.comments,
-    createdAt: r.createdAt.toISOString(),
+    createdAt: r.createdAt ? r.createdAt.toISOString() : undefined,
   };
 }
 


### PR DESCRIPTION
# fix: :bug: GET companies/:id toISOString on undefined

Fixes an issue where GET /companies/:id wouldn't work because .toISOString would be called on an undefined `createdAt` key.

## Types of Changes

<!-- What types of changes does your code introduce? Please tick all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Issue fix (non-breaking change that addresses existing opened issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring change (refactoring change must not apply any form of functional change)

## Fixes
N/A

## Notion Task Coverage
N/A
