### PR TITLE
feat: paused scrolling for advertisement carousel on hover

### DIFF
--- a/apps/marketplace/src/components/marketplace/carousel/AdvertisementCarousel.tsx
+++ b/apps/marketplace/src/components/marketplace/carousel/AdvertisementCarousel.tsx
@@ -37,7 +37,7 @@ const AdvertisementCarousel = ({ data }: AdvertisementCarouselProps) => {
   };
 
   return (
-    <Box sx={{ maxWidth: 'max', maxHeight: 300 }}>
+    <Box sx={{ maxWidth: 'max', maxHeight: 300, overflowY: 'hidden', }}>
       <AutoPlaySwipeableViews
         axis="x"
         index={activeStep}


### PR DESCRIPTION
paused scrolling for advertisement carousel on hover

# Title

feat: paused scrolling for advertisement carousel on hover

added a feat that pauses the carousel from moving if the user hovers over a advertisement

## Types of Changes

<!-- What types of changes does your code introduce? Please tick all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Issue fix (non-breaking change that addresses existing opened issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring change (refactoring change must not apply any form of functional change)

## Fixes

NA

## Notion Task Coverage

NA
