### PR TITLE
fix: :bug: listing query params wouldn't be optional

### DIFF
--- a/apps/admin/src/utils/api/server/zod/listings.ts
+++ b/apps/admin/src/utils/api/server/zod/listings.ts
@@ -9,10 +9,10 @@ import {
 
 const getQueryParameters = z.object({
   lastIdPointer: z.string().transform(zodParseToInteger).optional(),
-  limit: z.string().transform(zodParseToInteger).optional().default('10'),
+  limit: z.string().transform(zodParseToInteger).default('10').optional(),
   matching: z.string().optional(),
-  includeName: z.string().transform(zodParseToBoolean).optional().default('false'),
-  includeParameters: z.string().transform(zodParseToBoolean).optional().default('true'),
+  includeName: z.string().transform(zodParseToBoolean).default('false').optional(),
+  includeParameters: z.string().transform(zodParseToBoolean).default('true').optional(),
   params: z
     .preprocess(
       zodDecodeToJson,

--- a/apps/marketplace/src/utils/api/server/zod/listings.ts
+++ b/apps/marketplace/src/utils/api/server/zod/listings.ts
@@ -9,10 +9,10 @@ import {
 
 const getQueryParameters = z.object({
   lastIdPointer: z.string().transform(zodParseToInteger).optional(),
-  limit: z.string().transform(zodParseToInteger).optional().default('10'),
+  limit: z.string().transform(zodParseToInteger).default('10').optional(),
   matching: z.string().optional(),
-  includeName: z.string().transform(zodParseToBoolean).optional().default('false'),
-  includeParameters: z.string().transform(zodParseToBoolean).optional().default('true'),
+  includeName: z.string().transform(zodParseToBoolean).default('false').optional(),
+  includeParameters: z.string().transform(zodParseToBoolean).default('true').optional(),
   params: z
     .preprocess(
       zodDecodeToJson,


### PR DESCRIPTION
# fix: :bug: listing query params wouldn't be optional

Fixed a bug where the `includeName` and `includeParameters` query params on the listing GET endpoints wouldn't be optional

## Types of Changes

<!-- What types of changes does your code introduce? Please tick all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Issue fix (non-breaking change that addresses existing opened issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring change (refactoring change must not apply any form of functional change)

## Fixes
N/A

## Notion Task Coverage
N/A