### PR TITLE
Fix/profile popup alignment/htetaung

### DIFF
--- a/apps/marketplace/src/components/marketplace/navbar/Profile.tsx
+++ b/apps/marketplace/src/components/marketplace/navbar/Profile.tsx
@@ -90,7 +90,7 @@ const Profile = ({ userName, userId }: UserNameProps) => {
               display: 'block',
               position: 'absolute',
               top: 0,
-              right: 14,
+              right: 174,
               width: 10,
               height: 10,
               bgcolor: 'background.paper',


### PR DESCRIPTION
# Align the Profile pop up to be towards the right side
- Align the Profile pop up to be towards the right side

![image](https://github.com/kKar1503/project-inc-siwma-2/assets/74457508/d94c7617-b14b-411c-9e36-02fc26e33bf5)

<!-- The title should be the name of the pull request being made -->

<!-- 
	Describe your changes in detail

	Example:
	- Added a new feature

	This new feature is very cool because it allows users to do X, Y, and Z

	- Fixed a bug
	- I forgor
	- Updated the documentation
	- Ate a sandwich
	- etc.
 -->

## Types of Changes

<!-- What types of changes does your code introduce? Please tick all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Issue fix (non-breaking change that addresses existing opened issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring change (refactoring change must not apply any form of functional change)

## Fixes

<!-- If there's an issue fix involved in this PR, please link the related issues using `fixes #number`
fixes #5
fixes #11
fixes #15

N/A if not applicable
-->
N/A
## Notion Task Coverage

<!-- List down the Notion tasks that are covered by this PR
- ffeat/marketplace-thing/hinjourn
- bfeat/marketplace-thing/kar
- dfeat/marketplace-thing/george

N/A if not applicable
-->
[Align the Profile pop up to be towards the right side](https://www.notion.so/Align-the-Profile-pop-up-to-be-towards-the-right-side-2a807e15f17a4ceca70e28f3dd9cda0a?pvs=4)