### PR TITLE
feat: :sparkles: adds enum and fixes seeding script

### DIFF
--- a/packages/db-enums/index.ts
+++ b/packages/db-enums/index.ts
@@ -46,6 +46,7 @@ export const ReasonType = {
 export const UnitType = {
   'kg': 'kg',
   'm': 'm',
+  'mm': 'mm',
   'unit': 'unit',
 } as const;
 

--- a/packages/db/prisma/seeding/seed.ts
+++ b/packages/db/prisma/seeding/seed.ts
@@ -149,7 +149,7 @@ const main = async (): Promise<void> => {
     data: Offers,
   });
 
-  await prismaClient.$executeRaw`ALTER SEQUENCE public.offers_seq RESTART WITH ${offersCount};`;
+  await prismaClient.$executeRawUnsafe(`ALTER SEQUENCE public.offers_seq RESTART WITH ${offersCount};`);
 
   console.log(`Seeded ${offersCount} rows into public.offers`);
   console.log('Updated public.offers_seq');
@@ -159,10 +159,10 @@ const main = async (): Promise<void> => {
     data: Messages,
   });
 
-  await prismaClient.$executeRaw`ALTER SEQUENCE public.messages_seq RESTART WITH ${messagesCount};`;
+  await prismaClient.$executeRawUnsafe(`ALTER SEQUENCE public.messages_seq RESTART WITH ${messagesCount};`);
 
   console.log(`Seeded ${messagesCount} rows into public.messages`);
-  console.log('Seeding public.messages_seq...');
+  console.log('Updated public.messages_seq...');
   console.log('Seeding public.parameter...');
 
   const { count: parameterCount } = await prismaClient.parameter.createMany({


### PR DESCRIPTION
# feat: :sparkles: adds enum and fixes seeding script

updates db enums with new enum value in unittype enum

fixes some security issue in the seeding script which was detected by the last version change of prisma before v5

## Types of Changes

<!-- What types of changes does your code introduce? Please tick all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Issue fix (non-breaking change that addresses existing opened issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring change (refactoring change must not apply any form of functional change)

## Fixes

N/A

## Notion Task Coverage

N/A
