### PR TITLE
Fix bug where BaseTable re-selects already selected rows

### DIFF
--- a/apps/admin/src/components/tables/BaseTable/BaseTable.tsx
+++ b/apps/admin/src/components/tables/BaseTable/BaseTable.tsx
@@ -92,7 +92,7 @@ const BaseTable = (props: BaseTableProps) => {
     // !! FIXME: later
     // Select the row if it is not selected
     if (selectedRow === undefined) {
-      newSelected = newSelected.concat(selected, row);
+      newSelected = newSelected.concat(row);
     }
 
     // Unselect the row if it was selected


### PR DESCRIPTION
# Fix bug where BaseTable re-selects already selected rows

- Basically the BaseTable would duplicate the array of selected rows, causing previously selected rows to be selected again.
- This would lead to an exponential number of selected rows, everytime a row is selected
- Just know that this PR fixes a bug and it can be merged :)

## Types of Changes

<!-- What types of changes does your code introduce? Please tick all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Issue fix (non-breaking change that addresses existing opened issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring change (refactoring change must not apply any form of functional change)

## Fixes
N/A

## Notion Task Coverage
N/A
