### PR TITLE
Fixes an issue with the categories zod schema

### DIFF
--- a/apps/marketplace/src/utils/api/server/zod/categories.ts
+++ b/apps/marketplace/src/utils/api/server/zod/categories.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { zodParseToInteger } from '../../apiHelper';
 
 export const getCategoriesQueryParameter = z.object({
   includeParameters: z.string().optional(),
@@ -9,7 +10,7 @@ export const categoryRequestBody = z.object({
   description: z.string(),
   parameters: z
     .object({
-      parameterId: z.number(),
+      parameterId: z.string().transform(zodParseToInteger),
       required: z.boolean(),
     })
     .array(),
@@ -20,7 +21,7 @@ const editCategoryRequestBody = z.object({
   description: z.string().optional(),
   parameters: z
     .object({
-      parameterId: z.number(),
+      parameterId: z.string().transform(zodParseToInteger),
       required: z.boolean(),
     })
     .array()


### PR DESCRIPTION
# Fixes an issue with the categories zod schema

- It expected `parameterId` to be of type `number` when it should be of type `string`

## Types of Changes

<!-- What types of changes does your code introduce? Please tick all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Issue fix (non-breaking change that addresses existing opened issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring change (refactoring change must not apply any form of functional change)

## Fixes
N/A

## Notion Task Coverage
N/A